### PR TITLE
Updates dice retrieval logic for confirmation throws

### DIFF
--- a/lib/models/rules.dart
+++ b/lib/models/rules.dart
@@ -47,14 +47,17 @@ class AttributeRollResult {
   }
 
   List<Dice> get dice {
+    // Confirmation throw => 1. die normal, 2. die event die
+    if (roll?.confirmationThrow != null) {
+      return [
+        Dice.create(20, value: roll),
+        Dice.create(20, value: roll, event: event),
+      ];
+    }
+    // Otherwise just return the only die with the event (?)
+    // TODO: Confirm if wanted behaviour
     return [
-      Dice.create(20, event: event, value: roll),
-      if (roll?.confirmationThrow != null)
-        Dice.create(
-          20,
-          event: event,
-          value: DiceValue(roll!.confirmationThrow!),
-        ),
+      Dice.create(20, value: roll, event: event),
     ];
   }
 


### PR DESCRIPTION
Enhances the logic in the dice getter to handle confirmation throws more clearly.

Now, it returns two dice when a confirmation throw exists, ensuring correct event handling.

Additionally, a TODO comment is added to confirm the desired behavior for non-confirmation cases.